### PR TITLE
Fix off-by-one in `readUntil`

### DIFF
--- a/android/src/main/java/com/bluetoothserial/BluetoothSerialService.java
+++ b/android/src/main/java/com/bluetoothserial/BluetoothSerialService.java
@@ -349,7 +349,7 @@ public class BluetoothSerialService {
                 if (index >= 0) {
                     index += delimiter.length();
                     data = readBuffer.substring(0, index);
-                    readBuffer.delete(0, index+1);
+                    readBuffer.delete(0, index);
                 }
             }
 


### PR DESCRIPTION

The delimiter has already accounted for at this point by the `index += delimiter.length();` statement.

Fixes an issue where the next byte following a delimiter would be lost when the buffer had multiple delimiters.
